### PR TITLE
Allows the bot to AutoJoin the Stage Channel as soon as it is started

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # StageMusicBot
-Disclaimer: This Project was originally made to suit the needs of a single server, at the moment, some tweaks will be required to make it work for yours
+Disclaimer: This version of the bot was only tested on Linux, running with PM2 and restarts with a 6 hour CronoJob. It may not be suitable for normal use.
 
 [![Python version](https://img.shields.io/badge/python-3.9-blue.svg)](https://python.org)
 ![GitHub Repo stars](https://img.shields.io/github/stars/BritishBenji/StageMusicBot)

--- a/config.json.example
+++ b/config.json.example
@@ -3,7 +3,7 @@
 
     "prefix":"*",
 
-    "guild_id":"",
+    "bot_id":,
 
     "stage_name":"",
 

--- a/main.py
+++ b/main.py
@@ -106,7 +106,7 @@ async def nowplaying(ctx):
         title = audiofile.tag.title
         album = audiofile.tag.album
         embed = discord.Embed(color=0xc0f207)
-        embed.set_author(name="Now Playing â™ª", icon_url=ctx.guild.icon_url)
+        embed.set_author(name="Now Playing Ã¢â„¢Âª", icon_url=ctx.guild.icon_url)
         embed.add_field(
             name="Playing", value=f"{title} - {artist}", inline=False)
         if album != None:

--- a/main.py
+++ b/main.py
@@ -43,19 +43,18 @@ async def on_ready():
         async for guild in bot.fetch_guilds(limit=5):
             guilds.append(guild.name)
     print(guilds)
-
-
-@bot.command(name="join", description="Command to make bot join channel")
-@commands.has_role(config["mod_role"])
-async def join(ctx):
-    stage = discord.utils.get(ctx.guild.channels, name=config["stage_name"])
+    text_channel_list = []
+    for guild in bot.guilds:
+        for channel in guild.stage_channels:
+            text_channel_list.append(channel)
+    stage = discord.utils.get(text_channel_list, name=config["stage_name"])
     channel = stage.name
     global vc
     global tune
     try:
         vc = await stage.connect()
         self_user = bot.user
-        member = await ctx.guild.fetch_member(self_user.id)
+        member = guild.get_member(853638592785285120)
         await member.edit(suppress=False)
     except CommandInvokeError:
         pass
@@ -107,7 +106,7 @@ async def nowplaying(ctx):
         title = audiofile.tag.title
         album = audiofile.tag.album
         embed = discord.Embed(color=0xc0f207)
-        embed.set_author(name="Now Playing ♪", icon_url=ctx.guild.icon_url)
+        embed.set_author(name="Now Playing â™ª", icon_url=ctx.guild.icon_url)
         embed.add_field(
             name="Playing", value=f"{title} - {artist}", inline=False)
         if album != None:

--- a/main.py
+++ b/main.py
@@ -54,7 +54,7 @@ async def on_ready():
     try:
         vc = await stage.connect()
         self_user = bot.user
-        member = guild.get_member(853638592785285120)
+        member = guild.get_member(config["bot_id"])
         await member.edit(suppress=False)
     except CommandInvokeError:
         pass


### PR DESCRIPTION
### FEATURE UPDATE:
Allowing the bot to AutoJoin on Startup means that it can be run using PM2 (or another service like this) so that as soon as it ends (or crashes on a dodgy audio file), it will close, and start up again. Negating the need for someone to type a command in to get the bot back into the correct channel

*(This code has been tested for the past 4 days with PM2 and a CronJob to reset the process every 6 hours to prevent any cache from building up and to allow my RasPi some time to breathe)*